### PR TITLE
Make lookup methods overrideable

### DIFF
--- a/lib/api_me.rb
+++ b/lib/api_me.rb
@@ -108,7 +108,7 @@ module ApiMe
     render status: 204, nothing: true
   end
 
-  private
+  protected
 
   def object_params
     params.require(params_klass_symbol).permit(*policy(@object || model_klass).permitted_attributes)

--- a/lib/api_me/version.rb
+++ b/lib/api_me/version.rb
@@ -1,3 +1,3 @@
 module ApiMe
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
Originally the idea was that these should be overridable, but I found out that private methods included with active support concerns are not overridable. Bumped all private methods to protected.