### PR TITLE
Upgrade to AMS 0.10.x and make tests pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 script: bundle exec rspec spec
 rvm:
-  - 2.1.0
+  - 2.2.2

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ group :test do
   gem 'combustion', '~> 0.5.2'
   gem 'rack-test'
   gem 'pundit'
-  gem 'active_model_serializers', '~> 0.8.0'
+  gem 'active_model_serializers', '~> 0.10.0'
 end

--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ Api controllers use the fantastic [Pundit](https://github.com/elabs/pundit) gem 
 
 The primary goal of this gem was to keep things simple so that customization is fairly straight forward by separating concerns and providing overrides. Reusing existing libraries was a primary goal during the design, hence the overall simplicity of this gem. We currently use this gem internally at [Inigo](inigo.io) and are committed to its ongoing maintenance.
 
+### Upgrade from 0.7.X to 0.8.X
+- Upgrade to the latest version of 0.7.X. Run the app/tests and check/fix all deprecations
+- Upgrade to the latest version of 0.8.X, update active_model_serializers to 0.10.X.
+- Add the following initializer:
+  `config/initializers/active_model_serializer.rb`
+  ```rb
+  ActiveModelSerializers.config.adapter = :json
+  ```
+- Remove all `embed ...` methods from the serializers
+- Update all belongs-to relationships to have FKs, serialize the FK id in all active model serializers instead of embeding the relationship (I.E. `has_one :foo` becomes `attributes :foo_id`)
+- Update all has-many relationships to serialize the ids instead of embeding the relationship. (I.E. `has_many :foos` becomes `attributes :foo_ids`)
+- Remove all has-one relationships and manually build a method to serialize the id. Ex:
+  ```rb
+  attributes :foo_id
+
+  def foo_id
+    object.foo ? object.foo.id : nil
+  end
+  ```
+- Embeded has-one and belongs-to relationships look the same on the serializer, so look at the model to identify the differences.
+
 ### Installation
 Add the gem to your Gemfile: `gem api_me`.
 

--- a/api_me.gemspec
+++ b/api_me.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activerecord',             '>= 3.2.0'
   s.add_runtime_dependency 'activesupport',            '>= 3.2.0'
   s.add_runtime_dependency 'pundit',                   '~> 1.0'
-  s.add_runtime_dependency 'active_model_serializers', '~> 0.8.0'
+  s.add_runtime_dependency 'active_model_serializers', '~> 0.10.0'
   s.add_runtime_dependency 'search_object',            '~> 1.0'
   s.add_runtime_dependency 'kaminari',                 '~> 0.16.3'
 

--- a/lib/api_me.rb
+++ b/lib/api_me.rb
@@ -71,14 +71,14 @@ module ApiMe
     @sorted_scope = sort_scope(@filter_scope, params[:sort])
     @pagination_object = ApiMe::Pagination.new(scope: @sorted_scope, page_params: params[:page])
 
-    render json: @pagination_object.results, each_serializer: serializer_klass, meta: { page: @pagination_object.page_meta }
+    render json: @pagination_object.results, root: collection_root_key, each_serializer: serializer_klass, meta: { page: @pagination_object.page_meta }
   end
 
   def show
     @object = find_resource
     authorize @object
 
-    render json: @object, serializer: serializer_klass
+    render json: @object, root: singular_root_key, serializer: serializer_klass
   end
 
   def create
@@ -86,7 +86,7 @@ module ApiMe
     authorize @object
     @object.save!(object_params)
 
-    render status: 201, json: @object, serializer: serializer_klass
+    render status: 201, json: @object, root: singular_root_key, serializer: serializer_klass
   rescue ActiveRecord::RecordInvalid => e
     handle_errors(e)
   end
@@ -111,6 +111,14 @@ module ApiMe
   end
 
   protected
+
+  def singular_root_key
+    model_klass.name.singularize.underscore
+  end
+
+  def collection_root_key
+    model_klass.name.pluralize.underscore
+  end
 
   def object_params
     params.require(params_klass_symbol).permit(*policy(@object || model_klass).permitted_attributes)

--- a/lib/api_me/model.rb
+++ b/lib/api_me/model.rb
@@ -1,0 +1,6 @@
+require 'active_model_serializers/model'
+
+module ApiMe
+  class Model < ActiveModelSerializers::Model
+  end
+end

--- a/spec/acceptance/api/v1/posts_spec.rb
+++ b/spec/acceptance/api/v1/posts_spec.rb
@@ -58,7 +58,6 @@ describe 'Posts API' do
     get '/api/v1/posts?page%5Boffset%5D=3'
     json = JSON.parse(last_response.body)
     expect(json['posts'].length).to eq(0)
-
   end
 
   it 'is page size of 10 working for default offset of 1' do
@@ -158,5 +157,4 @@ describe 'Posts API' do
     expect(json['posts'].first['name']).to eq('Post19')
     expect(json['posts'].length).to eq(10)
   end
-
 end

--- a/spec/internal/app/models/post.rb
+++ b/spec/internal/app/models/post.rb
@@ -1,2 +1,3 @@
 class Post < ActiveRecord::Base
+  belongs_to :user
 end

--- a/spec/internal/app/models/test_model.rb
+++ b/spec/internal/app/models/test_model.rb
@@ -1,4 +1,6 @@
-class TestModel
+require 'active_model_serializers/model'
+
+class TestModel < ActiveModelSerializers::Model
   def self.create
     @created = true
   end

--- a/spec/internal/app/models/user.rb
+++ b/spec/internal/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ActiveRecord::Base
+  has_many :posts
 end

--- a/spec/internal/app/serializers/post_serializer.rb
+++ b/spec/internal/app/serializers/post_serializer.rb
@@ -1,3 +1,5 @@
 class PostSerializer < ActiveModel::Serializer
   attributes :name
+
+  has_one :user
 end

--- a/spec/internal/app/serializers/user_serializer.rb
+++ b/spec/internal/app/serializers/user_serializer.rb
@@ -1,4 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  embed :ids
   attributes :id, :username
 end

--- a/spec/internal/config/initializers/active_model_serializers.rb
+++ b/spec/internal/config/initializers/active_model_serializers.rb
@@ -1,0 +1,1 @@
+ActiveModelSerializers.config.adapter = :json

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -6,6 +6,7 @@ ActiveRecord::Schema.define do
 
   create_table :posts, force: true do |t|
     t.string :name
+    t.belongs_to :user, foreign_key: true
     t.timestamps
   end
 end


### PR DESCRIPTION
While running the tests, there are two obvious non-backwards compatible
issues. First, the `ActiveModel::Serializer.embed` class method no longer
exists. Instead, to embed has_many or has_one (non fk relations) ids, it is recommended to
implement these methods manually. I.E.:

```rb
attribte :comment_ids

def commend_ids
  object.comments.map { |c| c.id }
end
```

Second, for serializing non active record objects, inheriting from
`ActiveModel::Serializer` no longer works. It is recommended to
inherit from `ActiveModelSerializers::Model` instead. See
https://github.com/rails-api/active_model_serializers/blob/master/docs/general/rendering.md#serializing-non-activerecord-objects
for details. As non-backwards compatible issues become obvious,
deprecations will be implemented in the last released version of Api Me
0.7.x as they are identified, wherever possible.