### PR TITLE
Corrected sorting bug on master

### DIFF
--- a/lib/api_me/sorting.rb
+++ b/lib/api_me/sorting.rb
@@ -11,7 +11,7 @@ module ApiMe
     end
 
     def results
-      sorting? ? sort.scope : scope
+      sorting? ? sort(sort_criteria).scope : scope
     end
 
     def sort_meta

--- a/lib/api_me/version.rb
+++ b/lib/api_me/version.rb
@@ -1,3 +1,3 @@
 module ApiMe
-  VERSION = '0.8.1'
+  VERSION = '0.8.2'
 end


### PR DESCRIPTION
Sort criteria was only using the default properties. This fixes that and includes the patch version bump.
