### PR TITLE
Update sort_scope so that it is non-breaking from 0.9.0

### DIFF
--- a/lib/api_me.rb
+++ b/lib/api_me.rb
@@ -177,10 +177,10 @@ module ApiMe
     ).results
   end
 
-  def sort_scope(scope)
+  def sort_scope(scope, sortable_params=sort_params)
     sort_klass.new(
         scope: scope,
-        sort_params: sort_hash
+        sort_params: sortable_params
     ).results
   end
 
@@ -199,10 +199,6 @@ module ApiMe
 
   def filter_params
     params[:filters]
-  end
-
-  def sort_hash
-    sort_params
   end
 
   def sort_params


### PR DESCRIPTION
This updates the sort_scope changes so that it does not break from 9.0 or 8.x