### PR TITLE
Fix handle errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Deprecated
 ### Removed
 ### Fixed
+  * Added back `handle_errors` to prevent breakage in apps using this method.
 ### Security
 
 ## [0.10.2] - 2018-12-11

--- a/lib/api_me.rb
+++ b/lib/api_me.rb
@@ -165,6 +165,7 @@ module ApiMe
     Rails.logger.debug "ERROR: #{active_record_error}"
     render_errors(active_record_error.record.errors.messages)
   end
+  alias handle_errors handle_active_record_errors
 
   def user_not_authorized
     payload = { message: "User is not allowed to access #{params[:action]} on this resource" }


### PR DESCRIPTION
Add back `handle_errors` that was accidentally removed causing breakage in some apps.

